### PR TITLE
Check for browser string before doing string manipulation

### DIFF
--- a/src/JSONBuilder.js
+++ b/src/JSONBuilder.js
@@ -145,7 +145,7 @@ class JSONBuilder {
         browser: {
           name: options.browser,
           // @todo - check if it's possible to get the browser version from wdio events
-          version: options.browser.charAt(0).toUpperCase() + options.browser.slice(1),
+          version: options.browser ? options.browser.charAt(0).toUpperCase() + options.browser.slice(1) : '',
         },
         device: options.deviceName,
         platform: {


### PR DESCRIPTION
There are cases where `options.browser` can be empty, this is causing the reporter to crash when trying to run the `version: options.browser ? options.browser.charAt(0).toUpperCase() + options.browser.slice(1) : '',`.

This adds a check if it is empty before we do the string manipulation.